### PR TITLE
Store User ID When Mentor Creates a Quiz - Samira

### DIFF
--- a/api/middleware/mentorAuthMiddleware.js
+++ b/api/middleware/mentorAuthMiddleware.js
@@ -1,0 +1,22 @@
+import jwt from "jsonwebtoken";
+
+import config from "../utils/config.js";
+
+const JWT_SECRET = config.jwtSecret;
+
+export function mentorAuthMiddleware(req, res, next) {
+	const authHeader = req.headers["authorization"];
+	const token = authHeader && authHeader.split(" ")[1]; // Bearer TOKEN
+
+	if (!token) {
+		return res.status(401).json({ error: "Unauthorized - no token provided" });
+	}
+
+	jwt.verify(token, JWT_SECRET, (err, user) => {
+		if (err) {
+			return res.status(403).json({ error: "Forbidden - invalid token" });
+		}
+		req.user = user;
+		next();
+	});
+}

--- a/api/quiz/quizController.js
+++ b/api/quiz/quizController.js
@@ -1,16 +1,19 @@
+import { z } from "zod";
+
 import db from "../db.js";
 import logger from "../utils/logger.js";
 
-import { z } from "zod";
 
 // Define the schema for quiz creation
 const createQuizSchema = z.object({
-	title: z.string().nonempty("Title is required and must be a non-empty string."),
+	title: z
+		.string()
+		.nonempty("Title is required and must be a non-empty string."),
 	description: z.string().optional(),
 	duration: z
-	  .number({ invalid_type_error: "Duration must be a number." })
-	  .positive("Duration must be a positive number."),
-  });
+		.number({ invalid_type_error: "Duration must be a number." })
+		.positive("Duration must be a positive number."),
+});
 
 // Create a new quiz
 export async function createQuiz(req, res) {
@@ -19,26 +22,31 @@ export async function createQuiz(req, res) {
 		...req.body,
 		// Make sure to convert duration to a number since it might come as string
 		duration: Number(req.body.duration),
-	  });
-	
-	  if (!parseResult.success) {
+	});
+
+	if (!parseResult.success) {
 		const errorMessage =
-		parseResult.error.errors?.[0]?.message || "Invalid input data";
+			parseResult.error.errors?.[0]?.message || "Invalid input data";
 		// Log validation error to your logger
 		logger.error(`Validation error: ${errorMessage}`);
 		// Send first validation error message
 		return res.status(400).json({ message: errorMessage });
-	  }
-	
-	  const { title, description, duration } = parseResult.data;
+	}
 
+	const { title, description, duration } = parseResult.data;
+
+	// Get user ID from request ( auth middleware sets req.user)
+	const userId = req.user?.id;
+	if (!userId) {
+		return res.status(401).json({ message: "Unauthorized: User ID missing" });
+	}
 
 	try {
 		const result = await db.query(
-			`INSERT INTO quizzes (title, description, duration)
-			 VALUES ($1, $2, $3)
-			 RETURNING id, title, description, duration`,
-			[title, description, duration]
+			`INSERT INTO quizzes (title, description, duration,user_id)
+			 VALUES ($1, $2, $3, $4)
+			 RETURNING id, title, description, duration,user_id`,
+			[title, description, duration, userId],
 		);
 
 		const newQuiz = result.rows[0];
@@ -56,11 +64,11 @@ export async function createQuiz(req, res) {
 // Get a quiz along with its questions and options
 export async function getQuizById(req, res) {
 	const { quizId } = req.params;
-  
+
 	try {
-	  // Query to get quiz info + questions + options using JOINs
-	  const result = await db.query(
-		`
+		// Query to get quiz info + questions + options using JOINs
+		const result = await db.query(
+			`
 		SELECT 
 		  q.id as quiz_id, q.title, q.description, q.duration,
 		  qs.id as question_id, qs.text as question_text, qs.type,
@@ -71,87 +79,85 @@ export async function getQuizById(req, res) {
 		WHERE q.id = $1
 		ORDER BY qs.id, o.id
 		`,
-		[quizId]
-	  );
-  
-	  if (result.rows.length === 0) {
-		return res.status(404).json({ message: "Quiz not found" });
-	  }
-  
-	  // Use the first row as the base quiz object
-	  const base = result.rows[0];
-	  const quizData = {
-		id: base.quiz_id,
-		title: base.title,
-		description: base.description,
-		duration: base.duration,
-		questions: [],
-	  };
-  
-	  const questionsMap = new Map();
-  
-	  for (const row of result.rows) {
-		if (!row.question_id) continue; // no questions for this quiz
-  
-		if (!questionsMap.has(row.question_id)) {
-		  questionsMap.set(row.question_id, {
-			id: row.question_id,
-			text: row.question_text,
-			type: row.type,
-			options: [],
-		  });
-		}
-  
-		if (row.option_id) {
-		  questionsMap.get(row.question_id).options.push({
-			id: row.option_id,
-			text: row.option_text,
-			is_correct: row.is_correct,
-		  });
-		}
-	  }
-  
-	  quizData.questions = Array.from(questionsMap.values());
-  
-	  res.json(quizData);
-	} catch (error) {
-	  logger.error("Error fetching quiz:", error);
-	  res.status(500).json({ message: "Server error while fetching quiz" });
-	}
-  }
+			[quizId],
+		);
 
-  //Delete a quiz and its questions
-  export async function deleteQuiz(req, res) {
-	const { quizId } = req.params;
-  
-	try {
-	  // Delete options linked to questions of this quiz
-	  await db.query(
-		`DELETE FROM options 
-		 WHERE question_id IN (SELECT id FROM questions WHERE quiz_id = $1)`,
-		[quizId]
-	  );
-  
-	  // Delete questions linked to this quiz
-	  await db.query(
-		"DELETE FROM questions WHERE quiz_id = $1",
-		[quizId]
-	  );
-  
-  
-	  // Delete the quiz
-	  const result = await db.query(
-		"DELETE FROM quizzes WHERE id = $1 RETURNING *",
-		[quizId]
-	  );
-  
-	  if (result.rowCount === 0) {
-		return res.status(404).json({ message: "Quiz not found" });
-	  }
-  
-	  res.status(200).json({ message: "Quiz deleted successfully", quiz: result.rows[0] });
+		if (result.rows.length === 0) {
+			return res.status(404).json({ message: "Quiz not found" });
+		}
+
+		// Use the first row as the base quiz object
+		const base = result.rows[0];
+		const quizData = {
+			id: base.quiz_id,
+			title: base.title,
+			description: base.description,
+			duration: base.duration,
+			questions: [],
+		};
+
+		const questionsMap = new Map();
+
+		for (const row of result.rows) {
+			if (!row.question_id) continue; // no questions for this quiz
+
+			if (!questionsMap.has(row.question_id)) {
+				questionsMap.set(row.question_id, {
+					id: row.question_id,
+					text: row.question_text,
+					type: row.type,
+					options: [],
+				});
+			}
+
+			if (row.option_id) {
+				questionsMap.get(row.question_id).options.push({
+					id: row.option_id,
+					text: row.option_text,
+					is_correct: row.is_correct,
+				});
+			}
+		}
+
+		quizData.questions = Array.from(questionsMap.values());
+
+		res.json(quizData);
 	} catch (error) {
-	  logger.error("Error deleting quiz:", error);
-	  res.status(500).json({ message: "Server error while deleting quiz" });
+		logger.error("Error fetching quiz:", error);
+		res.status(500).json({ message: "Server error while fetching quiz" });
 	}
-  }
+}
+
+// Delete a quiz and its questions
+export async function deleteQuiz(req, res) {
+	const { quizId } = req.params;
+
+	try {
+		// Delete options linked to questions of this quiz
+		await db.query(
+			`DELETE FROM options 
+		 WHERE question_id IN (SELECT id FROM questions WHERE quiz_id = $1)`,
+			[quizId],
+		);
+
+		// Delete questions linked to this quiz
+		await db.query("DELETE FROM questions WHERE quiz_id = $1", [quizId]);
+
+		// Delete the quiz
+		const result = await db.query(
+			"DELETE FROM quizzes WHERE id = $1 RETURNING *",
+			[quizId],
+		);
+
+		if (result.rowCount === 0) {
+			return res.status(404).json({ message: "Quiz not found" });
+		}
+
+		res
+			.status(200)
+			.json({ message: "Quiz deleted successfully", quiz: result.rows[0] });
+	} catch (error) {
+		logger.error("Error deleting quiz:", error);
+		res.status(500).json({ message: "Server error while deleting quiz" });
+	}
+}

--- a/api/quiz/quizRouter.js
+++ b/api/quiz/quizRouter.js
@@ -1,19 +1,22 @@
 import { Router } from "express";
+
+import answerRouter from "../answers/answerRouter.js";
+import { mentorAuthMiddleware } from "../middleware/mentorAuthMiddleware.js";
+import questionRouter from "../questions/questionRouter.js";
+
 import { createQuiz, getQuizById, deleteQuiz } from "./quizController.js";
-import questionRouter from "../questions/questionRouter.js"
-import answerRouter from "../answers/answerRouter.js"
 
 const quizRouter = Router();
 
 // Route to create a new quiz
-quizRouter.post("/", createQuiz); // api/quizzes
+quizRouter.post("/", mentorAuthMiddleware, createQuiz); // api/quizzes
 // Route to Get quiz with id (questions and options)
-quizRouter.get("/:quizId", getQuizById) // Get api/quizzes/:quizId
+quizRouter.get("/:quizId", getQuizById); // Get api/quizzes/:quizId
 // Route to Delete quiz with id (questions and options)
-quizRouter.delete("/:quizId", deleteQuiz); //DELETE /api/quizzes/:quizId
+quizRouter.delete("/:quizId", deleteQuiz); // DELETE /api/quizzes/:quizId
 // Mount questionRouter to handle all question-related routes for a specific quiz
-quizRouter.use("/:quizId/questions", questionRouter)
+quizRouter.use("/:quizId/questions", questionRouter);
 // Mount answerRouter to handle all answer-related routes for a specific quiz
-quizRouter.use("/:quizId/answers",answerRouter)
+quizRouter.use("/:quizId/answers", answerRouter);
 
 export default quizRouter;


### PR DESCRIPTION


PR Description: Add User Association to Quiz Creation
This PR introduces several changes to ensure that when a mentor creates a quiz, their user_id is correctly stored in the quizzes table. This enables us to associate each quiz with the mentor who created it and later retrieve quizzes by user.

Changes Included:
Added mentorAuthMiddleware to verify JWT and extract user.id from the token.

 Updated createQuiz controller to include user_id in the INSERT statement.

Modified quizRouter to protect the quiz creation route using mentorAuthMiddleware.

Updated quizzes table schema to add user_id as a foreign key referencing the users table.

Why This Is Important:
It allows tracking and displaying quizzes created by specific mentors.

Enables better access control and personalization on the mentor dashboard.

Sets the foundation for showing quizzes per mentor or implementing mentor-specific analytics.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have carefully reviewed my own code
- [ ] I have commented my code
- [ ] I have updated any documentation
