### PR TITLE
Remove text Question Type from Frontend - Samira

### DIFF
--- a/web/src/pages/QuizEdit.jsx
+++ b/web/src/pages/QuizEdit.jsx
@@ -249,7 +249,7 @@ function QuizEdit() {
 							id="quiz-title"
 							value={quizTitle}
 							onChange={(e) => setQuizTitle(e.target.value)}
-							className="w-full p-2 border rounded"
+							className="w-full p-2 border rounded bg-purple-50 border-purple-200"
 							required
 						/>
 					</div>
@@ -264,7 +264,7 @@ function QuizEdit() {
 							id="quiz-description"
 							value={quizDescription}
 							onChange={(e) => setQuizDescription(e.target.value)}
-							className="w-full p-2 border rounded"
+							className="w-full p-2 border rounded  bg-purple-50 border-purple-200"
 							required
 						/>
 					</div>
@@ -280,7 +280,7 @@ function QuizEdit() {
 							type="number"
 							value={quizDurationMinutes}
 							onChange={handleDurationMinutesChange}
-							className="w-full p-2 border rounded"
+							className="w-full p-2 border rounded  bg-purple-50 border-purple-200"
 							required
 							min={1}
 						/>
@@ -314,7 +314,7 @@ function QuizEdit() {
 						</label>
 						<textarea
 							id="question-text"
-							className="border rounded px-2 py-1 w-full min-h-[60px] focus:outline-none focus:ring-2 focus:ring-purple-400"
+							className="border rounded px-2 py-1 w-full min-h-[60px] bg-purple-50 border-purple-200"
 							value={questionText}
 							onChange={(e) => setQuestionText(e.target.value)}
 							required


### PR DESCRIPTION
## Description

This PR removes all remaining references to the text question type from the frontend UI and logic. The text type had already been removed from the backend and database, but was still present in dropdowns, conditionals, and state declarations in the React codebase.

**Changes Made**

- Removed text option from the question type dropdown.

- Deleted related conditional logic and state (setCorrectAnswer, etc.).

- Cleaned up unused variables and ensured ESLint compliance.

Fixes #22 

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have carefully reviewed my own code
- [ ] I have commented my code
- [ ] I have updated any documentation
