### PR TITLE
Generate Join quiz link - POORIYA

### DIFF
--- a/web/src/pages/StudentJoin.jsx
+++ b/web/src/pages/StudentJoin.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useEffect } from "react";
-import { useNavigate } from "react-router";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 import getApiBaseUrl from "../services/apiBaseUrl";
 import {
@@ -17,6 +17,17 @@ function StudentJoin() {
 	const [showError, setShowError] = useState(false);
 	const [loading, setLoading] = useState(false);
 	const navigate = useNavigate();
+	const [searchParams] = useSearchParams();
+
+	const isQuizIdFromUrl = searchParams.has("quizId");
+
+	// On component mount, check for quizId in URL
+	useEffect(() => {
+		const quizIdFromUrl = searchParams.get("quizId");
+		if (quizIdFromUrl) {
+			setQuizId(quizIdFromUrl);
+		}
+	}, [searchParams]);
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
@@ -98,11 +109,12 @@ function StudentJoin() {
 					</label>
 					<input
 						id="quiz-id"
-						className="border rounded px-2 py-1 w-full"
+						className="border rounded px-2 py-1 w-full disabled:bg-gray-200 disabled:text-gray-500"
 						type="number"
 						value={quizId}
 						onChange={(e) => setQuizId(e.target.value)}
 						required
+						disabled={isQuizIdFromUrl}
 					/>
 				</div>
 				{error && <div className="text-red-600 text-sm">{error}</div>}


### PR DESCRIPTION
## Description
This feature allows mentors to easily invite students to a quiz using a shareable link. When a student uses this link, the Quiz ID is automatically pre-filled and locked on the join page

**On mentor's side:**
- Generates a shareable join link (`/student/join?quizId=...`) as soon as the mentor enters the live session page.

- Displays the link in a read-only input field with a "Copy" button for convenience.

**On Students' side:**

- Uses the `useSearchParams` hook to detect a `quizId` in the URL's query parameters upon loading.

- If a `quizId` is present, it pre-fills the "Quiz ID" input field and disables it to prevent changes.